### PR TITLE
uint can't be < 0

### DIFF
--- a/DS4Windows/DS4Control/UdpServer.cs
+++ b/DS4Windows/DS4Control/UdpServer.cs
@@ -194,9 +194,6 @@ namespace DS4Windows
 				uint packetSize = BitConverter.ToUInt16(localMsg, currIdx);
 				currIdx += 2;
 
-				if (packetSize < 0)
-					return;
-
 				packetSize += 16; //size of header
 				if (packetSize > localMsg.Length)
 					return;


### PR DESCRIPTION
Remove useless comparison that tests if uint variable is < 0.